### PR TITLE
Feature/classify

### DIFF
--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -286,13 +286,13 @@ class WP_Customize_Menus {
 			'priority'     => 30,
 		) );
 
-		// Rebrand the existing "Navigation" section to the global theme locations section.
+		// Rebrand the existing "Navigation" section title and add it to the global 'menus' panel.
 		$locations = get_registered_nav_menus();
 		$num_locations = count( array_keys( $locations ) );
 		$description = sprintf( _n( 'Your theme contains %s menu location. Select which menu you would like to use.', 'Your theme contains %s menu locations. Select which menu appears in each location.', $num_locations ), number_format_i18n( $num_locations ) );
 		$description .= '<br>' . __( 'You can also place menus in widget areas with the Custom Menu widget.' );
 
-		$this->manager->get_section( 'nav' )->title = __( 'Theme Locations' );
+		$this->manager->get_section( 'nav' )->title = __( 'Menu Locations' );
 		$this->manager->get_section( 'nav' )->description = $description;
 		$this->manager->get_section( 'nav' )->priority = 5;
 		$this->manager->get_section( 'nav' )->panel = 'menus';

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -296,7 +296,7 @@ class WP_Customize_Menus {
 		$this->manager->add_setting( 'menu_customizer_options', array(
 			'type' => 'menu_options',
 		) );
-		$this->manager->add_control( new WP_Menu_Options_Customize_Control( $manager, 'menu_customizer_options', array(
+		$this->manager->add_control( new WP_Menu_Options_Customize_Control( $this->manager, 'menu_customizer_options', array(
 			'section' => 'nav',
 			'priority' => 20,
 		) ) );
@@ -375,7 +375,7 @@ class WP_Customize_Menus {
 				) );
 
 				// Create a control for each menu item.
-				$this->manager->add_control( new WP_Customize_Menu_Item_Control( $manager, $menu_item_setting_id, array(
+				$this->manager->add_control( new WP_Customize_Menu_Item_Control( $this->manager, $menu_item_setting_id, array(
 					'label'       => $item->title,
 					'section'     => $section_id,
 					'priority'    => 10 + $i,
@@ -391,7 +391,7 @@ class WP_Customize_Menus {
 				'default'   => $item_ids,
 			) );
 
-			$this->manager->add_control( new WP_Customize_Nav_Menu_Control( $manager, $nav_menu_setting_id, array(
+			$this->manager->add_control( new WP_Customize_Nav_Menu_Control( $this->manager, $nav_menu_setting_id, array(
 				'section'   => $section_id,
 				'menu_id'   => $menu_id,
 				'priority'  => 998,
@@ -449,7 +449,7 @@ class WP_Customize_Menus {
 			'type' => 'new_menu',
 		) );
 
-		$this->manager->add_control( new WP_New_Menu_Customize_Control( $manager, 'create_new_menu', array(
+		$this->manager->add_control( new WP_New_Menu_Customize_Control( $this->manager, 'create_new_menu', array(
 			'section'  => 'add_menu',
 		) ) );
 	}

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -737,7 +737,7 @@ class WP_Customize_Menus {
 				);
 				$allposts = get_posts( $args );
 				foreach ( $allposts as $post ) {
-					$item[] = array(
+					$items[] = array(
 						'id'          => 'post-' . $post->ID,
 						'name'        => $post->post_title,
 						'type'        => $post_type->name,

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -95,7 +95,7 @@ class WP_Customize_Menus {
 			wp_die( -1 );
 		}
 
-		$menu_id = absint( $_POST['menu_id'] );
+		$menu_id = absint( $_POST['menu'] );
 
 		if ( is_nav_menu( $menu_id ) ) {
 			$deletion = wp_delete_nav_menu( $menu_id );

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -237,6 +237,11 @@ class WP_Customize_Menus {
 		wp_die();
 	}
 
+	/**
+	 * Enqueue scripts and styles.
+	 *
+	 * @since Menu Customizer 0.0
+	 */
 	public function enqueue() {
 		wp_enqueue_style( 'menu-customizer', plugin_dir_url( __FILE__ ) . 'menu-customizer.css', '0.0' );
 		wp_enqueue_script( 'menu-customizer-options', plugin_dir_url( __FILE__ ) . 'menu-customizer-options.js', array( 'jquery' ) );
@@ -645,8 +650,10 @@ class WP_Customize_Menus {
 	 * Skips the mess that is wp_update_nav_menu_item() and avoids
 	 * handling menu item fields that are not changed.
 	 *
-	 * Based on the parts of wp_update_nav_menu_item() that are needed here.
-	 * $menu_id must already be validated before running this function (to avoid re-validating for each item in the menu).
+	 * Based on the parts of wp_update_nav_menu_item() that are needed here. $menu_id must already be 
+	 * validated before running this function (to avoid re-validating for each item in the menu).
+	 *
+	 * @since Menu Customizer 0.0
 	 *
 	 * @param int $menu_id The valid ID of the menu.
 	 * @param int $item_id The ID of the (existing) menu item.
@@ -812,7 +819,9 @@ class WP_Customize_Menus {
 	}
 
 	/**
-	 * No docs yet
+	 * Return an array of all the available item types.
+	 *
+	 * @since Menu Customizer 0.0
 	 */
 	public function available_item_types() {
 		$types = get_post_types( array( 'show_in_nav_menus' => true ), 'names' );

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -628,7 +628,7 @@ class WP_Customize_Menus {
 		$i = 1;
 		foreach ( $items as $item_id ) {
 			// Assign the existing item to this menu, in case it's orphaned. Update the order, regardless.
-			$this->update_item_order( $menu_id, $item_id, $i );
+			$this->update_menu_item_order( $menu_id, $item_id, $i );
 			$i++;
 		}
 
@@ -639,7 +639,21 @@ class WP_Customize_Menus {
 		}
 	}
 
-	 public function update_menu_item_order( $menu_id, $item_id, $order ) {
+	/**
+	 * Updates the order for and publishes an existing menu item.
+	 *
+	 * Skips the mess that is wp_update_nav_menu_item() and avoids
+	 * handling menu item fields that are not changed.
+	 *
+	 * Based on the parts of wp_update_nav_menu_item() that are needed here.
+	 * $menu_id must already be validated before running this function (to avoid re-validating for each item in the menu).
+	 *
+	 * @param int $menu_id The valid ID of the menu.
+	 * @param int $item_id The ID of the (existing) menu item.
+	 * @param int $order   The menu item's new order/position.
+	 * @return int|WP_Error The menu item's database ID or WP_Error object on failure.
+	 */
+	public function update_menu_item_order( $menu_id, $item_id, $order ) {
 		$item_id = (int) $item_id;
 
 		// Make sure that we don't convert non-nav_menu objects into nav_menu_item_objects.

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -432,7 +432,7 @@ class WP_Customize_Menus {
 		$this->manager->add_section( 'add_menu', array(
 			'title'     => __( 'New Menu' ),
 			'panel'     => 'menus',
-			'priority'  => 99,
+			'priority'  => 999,
 		) );
 
 		$this->manager->add_setting( 'new_menu_name', array(

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -184,6 +184,7 @@ class WP_Customize_Menus {
 		}
 
 		// make the "Home" item into the custom link that it actually is.
+		// @todo: do we really need this - the standard menu screen doesn't, so why are we doing it?
 		if ( 'page' == $menu_item_data['type'] && 'custom' == $menu_item_data['obj_type'] ) {
 			$menu_item_data['type'] = 'custom';
 			$menu_item_data['url'] = home_url( '/' );

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -243,7 +243,7 @@ class WP_Customize_Menus {
 	 * @since Menu Customizer 0.0
 	 */
 	public function enqueue() {
-		wp_enqueue_style( 'menu-customizer', plugin_dir_url( __FILE__ ) . 'menu-customizer.css', '0.0' );
+		wp_enqueue_style( 'menu-customizer', plugin_dir_url( __FILE__ ) . 'menu-customizer.css' );
 		wp_enqueue_script( 'menu-customizer-options', plugin_dir_url( __FILE__ ) . 'menu-customizer-options.js', array( 'jquery' ) );
 		wp_enqueue_script( 'menu-customizer', plugin_dir_url( __FILE__ ) . 'menu-customizer.js', array( 'jquery', 'wp-backbone', 'customize-controls', 'accordion' ) );
 

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -238,7 +238,7 @@ class WP_Customize_Menus {
 	}
 
 	public function enqueue() {
-		wp_enqueue_style( 'menu-customizer', plugin_dir_url( __FILE__ ) . 'menu-customizer.css' );
+		wp_enqueue_style( 'menu-customizer', plugin_dir_url( __FILE__ ) . 'menu-customizer.css', '0.0' );
 		wp_enqueue_script( 'menu-customizer-options', plugin_dir_url( __FILE__ ) . 'menu-customizer-options.js', array( 'jquery' ) );
 		wp_enqueue_script( 'menu-customizer', plugin_dir_url( __FILE__ ) . 'menu-customizer.js', array( 'jquery', 'wp-backbone', 'customize-controls', 'accordion' ) );
 

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -584,6 +584,10 @@
 	margin-top: -1px;
 }
 
+#available-menu-items .menu-item-handle:hover {
+	z-index: 1;
+}
+
 #available-menu-items .item-title h4 {
 	padding: 0 0 5px;
 	font-size: 14px;

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -21,12 +21,12 @@
 .wp-customizer .menu-item-settings,
 .wp-customizer .menu-item-settings .description-thin {
 	-webkit-box-sizing: border-box;
-	-moz-box-sizing:    border-box;
-	box-sizing:         border-box;
+	-moz-box-sizing:	border-box;
+	box-sizing: 		border-box;
 }
 
 .wp-customizer .menu-item-bar {
-    margin: 0;
+	margin: 0;
 }
 
 .wp-customizer .menu-item-bar .menu-item-handle {
@@ -201,7 +201,7 @@
 }
 
 .reordering .menu-item-reorder-nav {
-    display: block;
+	display: block;
 }
 
 /* Targets the menu name inputs. */
@@ -295,7 +295,7 @@
 
 /* Screen Options */
 #customizer-menu-screen-options-button {
-    position: absolute;
+	position: absolute;
 	top: 36px;
 	right: 56px;
 	color: #555;
@@ -313,11 +313,11 @@
 }
 
 #customizer-menu-screen-options-button:after {
-    position: absolute;
+	position: absolute;
 	top: 0;
 	left: 0;
 	font: normal 20px/1 'dashicons';
-    content: "\f180";
+	content: "\f180";
 	display: block;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -559,15 +559,15 @@
 }
 
 #available-menu-items .menu-item-handle .item-type {
-    padding-right: 0;
+	padding-right: 0;
 }
 
 #available-menu-items .menu-item-handle .item-title {
-    padding-left: 20px;
+	padding-left: 20px;
 }
 
 #available-menu-items .menu-item-handle {
-    cursor: pointer;
+	cursor: pointer;
 }
 
 #available-menu-items .item-top,

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -21,8 +21,8 @@
 .wp-customizer .menu-item-settings,
 .wp-customizer .menu-item-settings .description-thin {
 	-webkit-box-sizing: border-box;
-	-moz-box-sizing:	border-box;
-	box-sizing: 		border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 .wp-customizer .menu-item-bar {

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1655,11 +1655,10 @@
 		// Deletes a menu (pending user confirmation).
 		submitDelete: function( el ) {
 			var params, dropdowns,
-				menu_id = $( el) .attr( 'id' ),
+				menuId = $( el ).attr( 'id' ).replace( 'delete-menu-', '' ),
 				section = $( el ).closest( '.accordion-section' ),
 				next = section.next().find( '.accordion-section-title' );
-			menu_id = menu_id.replace( 'delete-menu-', '' );
-			if ( menu_id ) {
+			if ( menuId ) {
 				// Prompt user with an AYS.
 				if ( confirm( api.Menus.data.l10n.deleteWarn ) ) {
 					section.addClass( 'deleting' );
@@ -1667,18 +1666,18 @@
 					// Delete the menu.
 					params = {
 						'action': 'delete-menu-customizer',
-						'menu_id': menu_id,
+						'menu': menuId,
 						'customize-nav-menu-nonce': api.Menus.data.nonce
 					};
 					$.post( wp.ajax.settings.url, params, function() {
 						// Remove the UI, once menu has been deleted.
-						section.slideUp( 'slow', function() {
+						section.slideUp( 'fast', function() {
 							section.remove(); // @todo core there should be API methods for deleting sections.
 						} );
 
 						// Remove the option from the theme location dropdowns.
 						dropdowns = $( '#accordion-section-nav .customize-control select' );
-						dropdowns.find( 'option[value=' + menu_id + ']' ).remove();
+						dropdowns.find( 'option[value=' + menuId + ']' ).remove();
 					} );
 				}
 			}

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1666,6 +1666,7 @@
 					// Delete the menu.
 					params = {
 						'action': 'delete-menu-customizer',
+						'wp_customize': 'on',
 						'menu': menuId,
 						'customize-nav-menu-nonce': api.Menus.data.nonce
 					};


### PR DESCRIPTION
#### Outstanding Known Issues
This is not an exhaustive list, but will aid is future development once this PR is merged into the `master` branch.

- [ ] If an empty menu is set to a location you cannot preview changes, even after a page refresh and items are added. You must add items before the menu location is set, it cannot start empty.
- [ ] When adding a new menu you cannot edit the name of it until you refresh the browser.
- [ ] AJAX requests should be converted to use `wp_send_json_error` and `wp_send_json_success` instead of `wp_die` to return a response for proper error handling.
- [ ] `submitDelete` should only remove the menu from the UI on success, it currently does regardless of the response.
- [ ] All inline documentation needs to be reviewed for completeness & accuracy.
- [ ] The CSS styles need to be reviewed. There appears to be some unused or misnamed code in `menu-customizer.css`.
- [ ] When you navigate away from the `menus` panel the active open menu should be closed when you navigate back.
- [ ] Needs unit tests.
- [ ] Review the UI in various browsers & mobile devices.
- [ ] Accessibility review.