### PR TITLE
AJAX errors, spinners, and various UI changes

### DIFF
--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -862,7 +862,7 @@ class WP_Customize_Menus {
 				<div class="menu-item menu-item-depth-0 menu-item-edit-inactive">
 					<dl class="menu-item-bar">
 						<dt class="menu-item-handle">
-							<span class="spinner" style="display: block;"></span>
+							<span class="spinner" style="visibility: visible;"></span>
 							<span class="item-type">{{ data.type_label }}</span>
 							<span class="item-title menu-item-title">{{ data.name }}</span>
 						</dt>

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -130,7 +130,7 @@ class WP_Customize_Menus {
 		$id = $this->update_item( 0, $item_id, $menu_item_data, $clone );
 
 		if ( is_wp_error( $id ) ) {
-		  wp_send_json_error( array( 'message' => wp_strip_all_tags( $id->get_error_message(), true ) ) );
+			wp_send_json_error( array( 'message' => wp_strip_all_tags( $id->get_error_message(), true ) ) );
 		} else {
 			wp_send_json_success( $id );
 		}

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -282,7 +282,7 @@ class WP_Customize_Menus {
 		// Create a panel for Menus.
 		$this->manager->add_panel( 'menus', array(
 			'title'        => __( 'Menus' ),
-			'description'  => __( '<p>This panel is used for managing your custom navigation menus. You can add pages, posts, categories, tags, and custom links to your menus.</p><p>Menus can be displayed in locations definedd by your theme, and also used in sidebars by adding a "Custom Menu" widget in the Widgets panel.</p>' ),
+			'description'  => '<p>' . __( 'This panel is used for managing your custom navigation menus. You can add pages, posts, categories, tags, and custom links to your menus.</p><p>Menus can be displayed in locations defined by your theme, and also used in sidebars by adding a "Custom Menu" widget in the Widgets panel.' ) . '</p><span class="button" id="toggle-menu-delete" tabindex="0">' . __( 'Delete an Existing Menu' ) . '</span>',
 			'priority'     => 30,
 		) );
 

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -63,23 +63,24 @@ class WP_Customize_Menus {
 		check_ajax_referer( 'customize-menus', 'customize-nav-menu-nonce' );
 
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => __( 'Error: invalid user capabilities.' ) ) );
 		}
 
 		$menu_name = sanitize_text_field( $_POST['menu-name'] );
+
+		if ( empty( $menu_name ) ) {
+			wp_send_json_error( array( 'message' => __( 'Menu name is required.' ) ) );
+		}
 
 		// Create the menu.
 		$menu_id = wp_create_nav_menu( $menu_name );
 
 		if ( is_wp_error( $menu_id ) ) {
-			// @todo error handling, ideally providing user feedback (most likely case here is a duplicate menu name).
-			wp_die();
+			wp_send_json_error( array( 'message' => wp_strip_all_tags( $menu_id->get_error_message(), true ) ) );
 		}
 
 		// Output the data for this new menu.
-		echo wp_json_encode( array( 'name' => $menu_name, 'id' => $menu_id ) );
-
-		wp_die();
+		wp_send_json_success( array( 'name' => $menu_name, 'id' => $menu_id ) );
 	}
 
 	/**
@@ -100,7 +101,7 @@ class WP_Customize_Menus {
 		if ( is_nav_menu( $menu_id ) ) {
 			$deletion = wp_delete_nav_menu( $menu_id );
 			if ( is_wp_error( $deletion ) ) {
-				wp_send_json_error( array( 'message' => $deletion->get_error_message() ) );
+				wp_send_json_error( array( 'message' => wp_strip_all_tags( $deletion->get_error_message(), true ) ) );
 			} else {
 				wp_send_json_success();
 			}

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -92,7 +92,7 @@ class WP_Customize_Menus {
 		check_ajax_referer( 'customize-menus', 'customize-nav-menu-nonce' );
 
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => __( 'Error: invalid user capabilities.' ) ) );
 		}
 
 		$menu_id = absint( $_POST['menu'] );
@@ -100,13 +100,13 @@ class WP_Customize_Menus {
 		if ( is_nav_menu( $menu_id ) ) {
 			$deletion = wp_delete_nav_menu( $menu_id );
 			if ( is_wp_error( $deletion ) ) {
-				echo $deletion->message();
+				wp_send_json_error( array( 'message' => $deletion->get_error_message() ) );
+			} else {
+				wp_send_json_success();
 			}
 		} else {
-			_e( 'Error: invalid menu to delete.' );
+			wp_send_json_error( array( 'message' => __( 'Error: invalid menu to delete.' ) ) );
 		}
-
-		wp_die();
 	}
 
 	/**

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -282,7 +282,7 @@ class WP_Customize_Menus {
 		// Create a panel for Menus.
 		$this->manager->add_panel( 'menus', array(
 			'title'        => __( 'Menus' ),
-			'description'  => '<p>' . __( 'This panel is used for managing your custom navigation menus. You can add pages, posts, categories, tags, and custom links to your menus.' ) . '</p><p>' . __( 'Menus can be displayed in locations defined by your theme, and also used in sidebars by adding a "Custom Menu" widget in the Widgets panel.' ) . '</p><span class="button" id="toggle-menu-delete" tabindex="0">' . __( 'Delete an Existing Menu' ) . '</span>',
+			'description'  => '<p>' . __( 'This panel is used for managing your custom navigation menus. You can add pages, posts, categories, tags, and custom links to your menus.' ) . '</p><p>' . __( 'Menus can be displayed in locations defined by your theme, and also used in sidebars by adding a "Custom Menu" widget in the Widgets panel.' ) . '</p>',
 			'priority'     => 30,
 		) );
 

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -120,7 +120,7 @@ class WP_Customize_Menus {
 		check_ajax_referer( 'customize-menus', 'customize-menu-item-nonce' );
 
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => __( 'Error: invalid user capabilities.' ) ) );
 		}
 
 		$clone = $_POST['clone'];
@@ -129,13 +129,11 @@ class WP_Customize_Menus {
 
 		$id = $this->update_item( 0, $item_id, $menu_item_data, $clone );
 
-		if ( ! is_wp_error( $id ) ) {
-			echo $id;
+		if ( is_wp_error( $id ) ) {
+		  wp_send_json_error( array( 'message' => wp_strip_all_tags( $id->get_error_message(), true ) ) );
 		} else {
-			echo $id->message();
+			wp_send_json_success( $id );
 		}
-
-		wp_die();
 	}
 
 	/**

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -146,7 +146,7 @@ class WP_Customize_Menus {
 		check_ajax_referer( 'customize-menus', 'customize-menu-item-nonce' );
 
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => __( 'Error: invalid user capabilities.' ) ) );
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/nav-menu.php';
@@ -205,8 +205,10 @@ class WP_Customize_Menus {
 		}
 
 		$items_id = wp_save_nav_menu_items( 0, array( 0 => $item_data ) );
-		if ( is_wp_error( $items_id ) || empty( $items_id ) ) {
-			wp_die( 0 );
+		if ( is_wp_error( $items_id ) ) {
+			wp_send_json_error( array( 'message' => wp_strip_all_tags( $items_id->get_error_message(), true ) ) );
+		} else if ( empty( $items_id ) ) {
+			wp_send_json_error( array( 'message' => __( 'Menu ID is required.' ) ) );
 		}
 
 		$item = get_post( $items_id[0] );
@@ -230,10 +232,10 @@ class WP_Customize_Menus {
 				'menu_id'     => $menu_id,
 				'item'        => $item,
 			) );
-			echo wp_json_encode( $control->json() );
+			wp_send_json_success( $control->json() );
 		}
 
-		wp_die();
+		wp_send_json_error( array( 'message' => __( 'The menu item could not be added.' ) ) );
 	}
 
 	/**

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -282,7 +282,7 @@ class WP_Customize_Menus {
 		// Create a panel for Menus.
 		$this->manager->add_panel( 'menus', array(
 			'title'        => __( 'Menus' ),
-			'description'  => '<p>' . __( 'This panel is used for managing your custom navigation menus. You can add pages, posts, categories, tags, and custom links to your menus.</p><p>Menus can be displayed in locations defined by your theme, and also used in sidebars by adding a "Custom Menu" widget in the Widgets panel.' ) . '</p><span class="button" id="toggle-menu-delete" tabindex="0">' . __( 'Delete an Existing Menu' ) . '</span>',
+			'description'  => '<p>' . __( 'This panel is used for managing your custom navigation menus. You can add pages, posts, categories, tags, and custom links to your menus.' ) . '</p><p>' . __( 'Menus can be displayed in locations defined by your theme, and also used in sidebars by adding a "Custom Menu" widget in the Widgets panel.' ) . '</p><span class="button" id="toggle-menu-delete" tabindex="0">' . __( 'Delete an Existing Menu' ) . '</span>',
 			'priority'     => 30,
 		) );
 

--- a/menu-customize-controls.php
+++ b/menu-customize-controls.php
@@ -38,11 +38,11 @@ class WP_Customize_Nav_Menu_Control extends WP_Customize_Control {
 		<span class="button-secondary add-new-menu-item" tabindex="0">
 			<?php _e( 'Add Links' ); ?>
 		</span>
-		<span class="add-menu-item-loading spinner"></span>
 		<span class="reorder-toggle" tabindex="0">
 			<span class="reorder"><?php _ex( 'Reorder', 'Reorder menu items in Customizer' ); ?></span>
 			<span class="reorder-done"><?php _ex( 'Done', 'Cancel reordering menu items in Customizer' ); ?></span>
 		</span>
+		<span class="add-menu-item-loading spinner"></span>
 		<span class="menu-delete-item">
 			<span class="menu-delete" id="delete-menu-{{ data.menu_id }}" tabindex="0">
 				<?php _e( 'Delete menu' ); ?> <span class="screen-reader-text">{{ data.menu_name }}</span>

--- a/menu-customize-controls.php
+++ b/menu-customize-controls.php
@@ -326,7 +326,6 @@ class WP_New_Menu_Customize_Control extends WP_Customize_Control {
 		?>
 		<span class="button button-primary" id="create-new-menu-submit" tabindex="0"><?php _e( 'Create Menu' ); ?></span>
 		<span class="spinner"></span>
-		<span class="button" id="toggle-menu-delete" tabindex="0"><?php _e( 'Delete an Existing Menu' ); ?></span>
 		<?php
 	}
 }

--- a/menu-customize-controls.php
+++ b/menu-customize-controls.php
@@ -275,6 +275,7 @@ class WP_Customize_Menu_Item_Control extends WP_Customize_Control {
 						</p>
 					<# } #>
 					<a class="item-delete submitdelete deletion" id="delete-menu-item-{{ data.menu_item_id }}" href="#"><?php _e( 'Remove' ); ?></a>
+					<span class="spinner"></span>
 				</div>
 				<input type="hidden" name="menu-item-parent-id" class="menu-item-parent-id" id="edit-menu-item-parent-id-{{ data.menu_item_id }}" value="{{ data.parent }}" />
 			</div><!-- .menu-item-settings-->

--- a/menu-customize-controls.php
+++ b/menu-customize-controls.php
@@ -43,8 +43,10 @@ class WP_Customize_Nav_Menu_Control extends WP_Customize_Control {
 			<span class="reorder"><?php _ex( 'Reorder', 'Reorder menu items in Customizer' ); ?></span>
 			<span class="reorder-done"><?php _ex( 'Done', 'Cancel reordering menu items in Customizer' ); ?></span>
 		</span>
-		<span class="menu-delete" id="delete-menu-{{ data.menu_id }}" tabindex="0">
-			<span class="screen-reader-text"><?php _e( 'Delete menu:' ); ?> {{ data.menu_name }}</span>
+		<span class="menu-delete-item">
+			<span class="menu-delete" id="delete-menu-{{ data.menu_id }}" tabindex="0">
+				<?php _e( 'Delete menu' ); ?> <span class="screen-reader-text">{{ data.menu_name }}</span>
+			</span>
 		</span>
 	<?php
 	}

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -287,12 +287,6 @@
 	margin-top: 4px;
 }
 
-/* Updating Indicator */
-.nav-menu-item-wrap.saving .menu-item-handle .spinner {
-	display: inline;
-	margin-top: -1px;
-}
-
 /* Screen Options */
 #customizer-menu-screen-options-button {
 	position: absolute;
@@ -474,12 +468,7 @@
 	transform: rotate(45deg);
 }
 
-/* Existing menu item bar, with item delete button. */
 .adding-menu-items .menu-item .item-delete {
-	position: absolute;
-	top: 0;
-	right: 0;
-	font-size: 0;
 	color: #a00;
 }
 
@@ -488,20 +477,9 @@
 	color: #f00;
 }
 
-.adding-menu-items .menu-item .item-delete:before {
-	content: "\f335";
-	font-size: 30px;
-	top: 6px;
-	right: 4px;
-}
-
 .adding-menu-items .menu-item-handle .is-submenu,
 .adding-menu-items .menu-item-handle .item-edit {
 	display: none;
-}
-
-.adding-menu-items .menu-item-handle .item-type {
-	padding-right: 24px;
 }
 
 #available-menu-items .item {
@@ -648,9 +626,14 @@ body.adding-menu-items #customize-preview {
 	opacity: 0.4;
 }
 
-.nav-menu-inserted-item-loading .spinner {
+.menu-item-handle .spinner {
+	display: none;
 	float: left;
 	margin: 0 8px 0 0;
+}
+
+.nav-menu-inserted-item-loading .spinner {
+	display: block;
 }
 
 .nav-menu-inserted-item-loading .menu-item-handle .item-type {

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -676,6 +676,7 @@ body.adding-menu-items #customize-preview {
 
 #toggle-menu-delete {
 	float: right;
+	margin: .5em 0;
 }
 
 .menu-delete {
@@ -718,7 +719,7 @@ body.adding-menu-items #customize-preview {
 	display: none;
 }
 
-.deleting-menus #toggle-menu-delete {
+#toggle-menu-delete.deleting-menus {
 	background: #eee;
 	border-color: #999;
 	color: #333;
@@ -726,7 +727,7 @@ body.adding-menu-items #customize-preview {
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
-.deleting-menus #toggle-menu-delete:before {
+#toggle-menu-delete.deleting-menus:before {
 	content: "\f132";
 	display: inline-block;
 	position: relative;

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -75,25 +75,12 @@
 	padding: 0;
 }
 
-.wp-customizer .menu-item .submitbox .submitdelete {
-	padding: 2px 0;
-}
-
-.wp-customizer .menu-item .item-delete:before {
-	content: "\f158";
-	font: normal 20px/1 dashicons;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	position: relative;
-	top: 5px;
-	right: 1px;
-}
-
 .wp-customizer .menu-item-settings .link-to-original {
 	padding: 5px 0;
 	border: none;
 	font-style: normal;
 	margin: 0;
+	width: 100%;
 }
 
 .wp-customizer .menu-item-settings .link-to-original a {
@@ -110,6 +97,13 @@
 	top: 4px;
 	left: 2px;
 	display: inline-block;
+}
+
+.wp-customizer .menu-item .submitbox .submitdelete {
+	display: block;
+	float: left;
+	margin: .5em 0;
+	padding: 0;
 }
 
 /* Menu-item reordering nav. */

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -671,7 +671,6 @@ body.adding-menu-items #customize-preview {
 .menu-delete-item {
   display: block;
   float: left;
-  text-align: right;
   padding: 1em 0;
 	width: 100%;
 }

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -418,7 +418,7 @@
 #customize-theme-controls .add-new-menu-item {
 	cursor: pointer;
 	float: right;
-	margin-left: 10px;
+	margin-left: 5px;
 	-webkit-transition: all 0.2s;
 	transition: all 0.2s;
 	-webkit-user-select: none;
@@ -664,7 +664,7 @@ body.adding-menu-items #customize-preview {
 #accordion-section-add_menu .accordion-section-title:before {
 	font: normal 20px/1 dashicons;
 	position: absolute;
-	top: 11px;
+	top: 12px;
 	left: 14px;
 	content: "\f132";
 }
@@ -674,74 +674,23 @@ body.adding-menu-items #customize-preview {
 	margin: 0 0 12px 0;
 }
 
-#toggle-menu-delete {
-	float: right;
-	margin: .5em 0;
+.menu-delete-item {
+  display: block;
+  float: left;
+  text-align: right;
+  padding: 1em 0;
+	width: 100%;
 }
 
 .menu-delete {
-	display: none;
-}
-
-.menu-delete:before {
-	font: normal 20px/1 dashicons;
-	content: "\f158";
-	position: absolute;
-	top: 11px;
-	right: 9px;
 	color: #a00;
+	cursor: pointer;
+	text-decoration: underline;
 }
 
-.menu-delete:focus:before,
-.menu-delete:hover:before {
+.menu-delete:hover {
 	color: #f00;
-}
-
-.deleting-menus .menu-delete {
-	display: block;
-}
-
-.deleting-menus .accordion-section-title:after {
-	display: none;
-}
-
-/* Displayed while the menu-deletion ajax is processing. */
-#customize-theme-controls .accordion-section.deleting .accordion-section-title {
-	background: #a00;
-	color: #fff;
-}
-
-#customize-theme-controls .deleting-menus .accordion-section-title {
-	transition: .18s background ease-in-out;
-}
-
-#customize-theme-controls .accordion-section.deleting .menu-delete {
-	display: none;
-}
-
-#toggle-menu-delete.deleting-menus {
-	background: #eee;
-	border-color: #999;
-	color: #333;
-	-webkit-box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
-	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
-}
-
-#toggle-menu-delete.deleting-menus:before {
-	content: "\f132";
-	display: inline-block;
-	position: relative;
-	left: -2px;
-	top: -1px;
-	font: normal 20px/1 'dashicons';
-	vertical-align: middle;
-	-webkit-transition: all 0.2s;
-	transition: all 0.2s;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	-webkit-transform: rotate(45deg);
-	-ms-transform: rotate(45deg);
-	transform: rotate(45deg);
+	text-decoration: none;
 }
 
 /* Media queries */

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1662,7 +1662,7 @@
 				// Prompt user with an AYS.
 				if ( confirm( api.Menus.data.l10n.deleteWarn ) ) {
 					section.addClass( 'deleting' );
-					next.focus();
+
 					// Delete the menu.
 					params = {
 						'action': 'delete-menu-customizer',
@@ -1670,15 +1670,26 @@
 						'menu': menuId,
 						'customize-nav-menu-nonce': api.Menus.data.nonce
 					};
-					$.post( wp.ajax.settings.url, params, function() {
-						// Remove the UI, once menu has been deleted.
-						section.slideUp( 'fast', function() {
-							section.remove(); // @todo core there should be API methods for deleting sections.
-						} );
+					$.post( wp.ajax.settings.url, params, function( response ) {
+						if ( response.data && response.data.message ) {
+							// Display error message
+							alert( response.data.message );
 
-						// Remove the option from the theme location dropdowns.
-						dropdowns = $( '#accordion-section-nav .customize-control select' );
-						dropdowns.find( 'option[value=' + menuId + ']' ).remove();
+							// Remove the CSS class
+							section.removeClass( 'deleting' );
+						} else if ( response.success ) {
+							// Focus the next menu item
+							next.focus();
+
+							// Remove the UI, once menu has been deleted.
+							section.slideUp( 'fast', function() {
+								section.remove(); // @todo core there should be API methods for deleting sections.
+							} );
+
+							// Remove the option from the theme location dropdowns.
+							dropdowns = $( '#accordion-section-nav .customize-control select' );
+							dropdowns.find( 'option[value=' + menuId + ']' ).remove();
+						}
 					} );
 				}
 			}

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1645,9 +1645,13 @@
 
 		// Toggles menu-deletion mode for all menus.
 		toggleDelete: function() {
-			var container = $( '#accordion-panel-menus' );
+			$( '#toggle-menu-delete' ).toggleClass( 'deleting-menus' );
 
-			container.toggleClass( 'deleting-menus' );
+			$( '#accordion-panel-menus .accordion-section' ).each( function() {
+				if ( $( this ).find( '.menu-delete' ).length ) {
+					$( this ).toggleClass( 'deleting-menus' );
+				}
+			} );
 
 			return false;
 		},

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -385,11 +385,6 @@
 				control.collapseForm();
 			} );
 
-			// Move delete buttons into the title bar.
-			_( this.currentMenuControl.getMenuItemControls() ).each( function( control ) {
-				control.toggleDeletePosition( true );
-			} );
-
 			this.$el.find( '.selected' ).removeClass( 'selected' );
 
 			// Reset search
@@ -406,11 +401,6 @@
 			if ( options.returnFocus && this.currentMenuControl ) {
 				this.currentMenuControl.container.find( '.add-new-menu-item' ).focus();
 			}
-
-			// Move delete buttons back to the title bar.
-			_( this.currentMenuControl.getMenuItemControls() ).each( function( control ) {
-				control.toggleDeletePosition( false );
-			} );
 
 			this.currentMenuControl = null;
 			this.selected = null;
@@ -821,26 +811,6 @@
 				self.container.trigger( 'collapse' );
 
 				$inside.slideUp( 'fast', complete );
-			}
-		},
-
-		/**
-		 * Move the control's delete button up to the title bar or down to the control body.
-		 *
-		 * @param {boolean|undefined} [top] If not supplied, will be inverse of current visibility.
-		 */
-		toggleDeletePosition: function( top ) {
-			var button, handle, actions;
-			// @TODO: default handling.
-
-			button = this.container.find( '.item-delete' );
-			handle = this.container.find( '.menu-item-handle' );
-			actions = this.container.find( '.menu-item-actions' );
-			if ( top ) {
-				handle.append( button );
-			}
-			else {
-				actions.append( button );
 			}
 		},
 
@@ -1474,8 +1444,6 @@
 
 				// Make sure the panel hasn't been closed in the meantime.
 				if ( $( 'body' ).hasClass( 'adding-menu-items' ) ) {
-					// Move the delete button up to match the existing items.
-					api.Menus.getMenuItemControl( dbid ).toggleDeletePosition( true );
 					api.Menus.refreshVisibleMenuOptions();
 				}
 

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -220,7 +220,8 @@
 		},
 
 		toggleLoading: function( tf ) {
-			$( '.add-menu-item-loading' ).toggle( tf );
+			var visibility = true === tf ? 'visible' : 'hidden';
+			$( '.add-menu-item-loading' ).css( 'visibility', visibility );
 		},
 
 		// Performs a search and handles selected menu item.
@@ -1625,8 +1626,13 @@
 			var params, dropdowns,
 				menuId = $( el ).attr( 'id' ).replace( 'delete-menu-', '' ),
 				section = $( el ).closest( '.accordion-section' ),
-				next = section.next().find( '.accordion-section-title' );
+				next = section.next().find( '.accordion-section-title' ),
+				spinner = section.find( '.add-menu-item-loading.spinner' );
+
 			if ( menuId ) {
+				// Show spinner.
+				spinner.css( 'visibility', 'visible' );
+
 				// Prompt user with an AYS.
 				if ( confirm( api.Menus.data.l10n.deleteWarn ) ) {
 					section.addClass( 'deleting' );
@@ -1658,7 +1664,12 @@
 							dropdowns = $( '#accordion-section-nav .customize-control select' );
 							dropdowns.find( 'option[value=' + menuId + ']' ).remove();
 						}
+						// Hide spinner.
+						spinner.css( 'visibility', 'hidden' );
 					} );
+				} else {
+					// Hide spinner.
+					spinner.css( 'visibility', 'hidden' );
 				}
 			}
 		}

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1328,9 +1328,17 @@
 		 * Move menu-delete button to section title. Actual deletion is managed with api.Menus.NewMenuControl.
 		 */
 		_setupDeletion: function() {
-			var title = this.$controlSection.find( '.accordion-section-title' ),
-				deleteBtn = this.container.find( '.menu-delete' );
-			title.append( deleteBtn );
+			var self = this;
+
+			this.container.find( '.menu-delete' ).on( 'click keydown', function( event ) {
+				if ( event.type === 'keydown' && ! ( event.which === 13 || event.which === 32 ) ) { // Enter or Spacebar
+					return;
+				}
+
+				if ( self.$sectionContent.hasClass( 'deleting' ) ) {
+					return;
+				}
+			} );
 		},
 
 		/**
@@ -1509,8 +1517,7 @@
 		_bindHandlers: function() {
 			var self = this,
 				name = $( '#customize-control-new_menu_name input' ),
-				submit = $( '#create-new-menu-submit' ),
-				toggle = $( '#toggle-menu-delete' );
+				submit = $( '#create-new-menu-submit' );
 			name.on( 'keydown', function( event ) {
 				if ( event.which === 13 ) { // Enter.
 					self.submit();
@@ -1518,9 +1525,6 @@
 			} );
 			submit.on( 'click', function() {
 				self.submit();
-			} );
-			toggle.on( 'click', function() {
-				self.toggleDelete();
 			} );
 			$( '#accordion-panel-menus' ).on( 'click keydown', '.menu-delete', function( e ) {
 				if ( 'keydown' === e.type && 13 !== event.which ) { // Enter.
@@ -1639,19 +1643,6 @@
 				// Focus on the new menu section.
 				api.section( sectionId ).focus(); // @todo should we focus on the new menu's control and open the add-items panel? Thinking user flow...
 			});
-
-			return false;
-		},
-
-		// Toggles menu-deletion mode for all menus.
-		toggleDelete: function() {
-			$( '#toggle-menu-delete' ).toggleClass( 'deleting-menus' );
-
-			$( '#accordion-panel-menus .accordion-section' ).each( function() {
-				if ( $( this ).find( '.menu-delete' ).length ) {
-					$( this ).toggleClass( 'deleting-menus' );
-				}
-			} );
 
 			return false;
 		},

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1,4 +1,4 @@
-/* global _wpCustomizeMenusSettings, confirm */
+/* global _wpCustomizeMenusSettings, confirm, alert */
 (function( wp, $ ){
 	'use strict';
 
@@ -482,7 +482,7 @@
 			var container = this;
 			container.contentEmbedded = false;
 
-			api.Section.prototype.initialize.apply( this, arguments );
+			api.Section.prototype.initialize.call( this, id, options );
 		},
 
 		/**
@@ -503,7 +503,7 @@
 				} );
 				section.contentEmbedded = true;
 			}
-			api.Section.prototype.onChangeExpanded.apply( this, arguments );
+			api.Section.prototype.onChangeExpanded.call( this, expanded, args );
 		}
 	});
 

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1,4 +1,4 @@
-/* global _wpCustomizeMenusSettings, confirm, JSON */
+/* global _wpCustomizeMenusSettings, confirm */
 (function( wp, $ ){
 	'use strict';
 


### PR DESCRIPTION
- [x] AJAX requests should be converted to use `wp_send_json_error` and `wp_send_json_success` instead of `wp_die` to return a response for proper error handling.
- [x] `submitDelete` should only remove the menu from the UI on success, it currently does regardless of the response.
- [x] Fix the menu delete UI
- [x] Fix spinners