### PR TITLE
Partial refresh integration

### DIFF
--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -261,6 +261,7 @@ class WP_Customize_Menus {
 				'custom_label'    => _x( 'Custom', 'Custom menu item type label.' ),
 				'deleteWarn'      => __( 'You are about to permanently delete this menu. "Cancel" to stop, "OK" to delete.' ),
 			),
+			'menuItemTransport'    => apply_filters( 'temp_menu_customizer_previewable_setting_transport', 'refresh' ),
 		);
 
 		$data = sprintf( 'var _wpCustomizeMenusSettings = %s;', json_encode( $settings ) );
@@ -394,8 +395,9 @@ class WP_Customize_Menus {
 			// Add the menu control, which handles adding and ordering.
 			$nav_menu_setting_id = 'nav_menu_' . $menu_id;
 			$this->manager->add_setting( $nav_menu_setting_id, array(
-				'type'     => 'nav_menu',
+				'type'      => 'nav_menu',
 				'default'   => $item_ids,
+				'transport' => apply_filters( 'temp_menu_customizer_previewable_setting_transport', 'refresh' ),
 			) );
 
 			$this->manager->add_control( new WP_Customize_Nav_Menu_Control( $this->manager, $nav_menu_setting_id, array(

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -357,11 +357,11 @@ class WP_Customize_Menus {
 								// @TODO: This should be supplied already
 								$incoming_setting_value->ID = $matches['menu_item_id'];
 							}
-							if ( ! isset ( $incoming_setting_value->title ) ) {
+							if ( ! isset( $incoming_setting_value->title ) ) {
 								// @TODO: This should be supplied already
 								$incoming_setting_value->title = 'UNTITLED';
 							}
-							if ( ! isset ( $incoming_setting_value->menu_item_parent ) ) {
+							if ( ! isset( $incoming_setting_value->menu_item_parent ) ) {
 								// @TODO: This should be supplied already
 								$incoming_setting_value->menu_item_parent = 0;
 							}

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -555,9 +555,8 @@
 		 * @since 4.1.0
 		 *
 		 * @param {Boolean} expanded
-		 * @param {Object}  args
 		 */
-		onChangeExpanded: function ( expanded, args ) {
+		onChangeExpanded: function ( expanded ) {
 			var section = this,
 			    button = section.container.find( '.add-menu-toggle' ),
 				content = section.container.find( '.new-menu-section-content' );
@@ -568,7 +567,7 @@
 				button.removeClass( 'open' );
 				content.slideUp( 'fast' );
 			}
-		}		
+		}
 	});
 
 	/**

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -843,12 +843,13 @@
 				'customize-menu-item-nonce': api.Menus.data.nonce
 			};
 
+			// @todo replace this with wp.ajax.post()
 			$.post( wp.ajax.settings.url, params, function( response ) {
 				var id, menuControl, menuItemIds, i;
 				if ( response.data && response.data.message ) {
 					// Display error message
 					alert( response.data.message );
-				} else if ( response.success && response.data && clone ) {
+				} else if ( response.success && response.data ) {
 					id = response.data;
 
 					// Update item control accordingly with new id.
@@ -861,20 +862,27 @@
 					// Replace original id of this item with cloned id in the menu setting.
 					menuControl = api.Menus.getMenuControl( self.params.menu_id );
 
-					menuItemIds = menuControl.setting().slice();
-					i = _.indexOf( menuItemIds, self.params.original_id );
+					if ( clone ) {
 
-					menuItemIds[i] = id;
-					menuControl.setting( menuItemIds );
+						menuItemIds = menuControl.setting().slice();
+						i = _.indexOf( menuItemIds, self.params.original_id );
 
-					// Update parent id for direct children items.
-					api.control.each( function( control ) {
-						if ( control.params.type === 'menu_item' && self.params.original_id === parseInt( control.params.menu_item_parent_id, 10 ) ) {
-							control.params.menu_item_parent_id = id;
-							control.container.find( '.menu-item-parent-id' ).val( id );
-							control.updateMenuItem(); // @todo this requires cloning all direct children, which will in turn recursively clone all submenu items - works, but is there a better approach?
-						}
-					} );
+						menuItemIds[i] = id;
+						menuControl.setting( menuItemIds );
+
+						// Update parent id for direct children items.
+						api.control.each( function( control ) {
+							if ( control.params.type === 'menu_item' && self.params.original_id === parseInt( control.params.menu_item_parent_id, 10 ) ) {
+								control.params.menu_item_parent_id = id;
+								control.container.find( '.menu-item-parent-id' ).val( id );
+								control.updateMenuItem(); // @todo this requires cloning all direct children, which will in turn recursively clone all submenu items - works, but is there a better approach?
+							}
+						} );
+					} else {
+						// There would be no change to the value, so just re-trigger a preview
+						// @todo There should really be Customizer settings that contain all of the menu item fields
+						menuControl.setting.preview();
+					}
 				}
 
 				// Remove processing states.

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -699,9 +699,9 @@
 			} );
 
 			// Regular menu item update triggering - on change.
-			$menuItemContent.on( 'change', ':input', function() {
+			$menuItemContent.on( 'change input propertychange', ':input', _.debounce( function() {
 				self.updateMenuItem();
-			} );
+			}, 500 ) );
 
 			// When saving, update original_id to menu_item_id, initiating new clones as needed.
 			api.bind( 'save', function() {

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -26,7 +26,7 @@
 	 * @augments Backbone.Model
 	 */
 	api.Menus.MenuItemModel = Backbone.Model.extend({
-		transport: 'refresh',
+		transport: api.Menus.data.menuItemTransport,
 		params: [],
 		menu_item_id: null,
 		original_id: 0,


### PR DESCRIPTION
Test with https://github.com/xwp/wp-customize-partial-refresh/pull/12

For instance, assuming you have `menu-customizer` checked out via Git, you can checkout the required branch for Menu Customizer and also clone and checkout the branch for Customize Partial Refresh via something like:

```bash
cd wp-content/plugins/menu-customizer
git fetch
git checkout feature/partial-refresh
cd ..
git clone https://github.com/xwp/wp-customize-partial-refresh.git customize-partial-refresh
cd customize-partial-refresh
git checkout feature/menus
wp plugin activate customize-partial-refresh
```

Note that only the Core themes have menu partial refresh enabled by default. For other themes, support can be indicated via:

```php
add_theme_support( 'customize-partial-refresh-menus' );
```