### PR TITLE
Add a missing event object to delete click callback. Fixes #60.

### DIFF
--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -155,7 +155,7 @@
 					self.close();
 				}
 			} );
-			
+
 			this.$el.on( 'input', '#custom-menu-item-name.invalid, #custom-menu-item-url.invalid', function( event ) {
 				$( this ).removeClass( 'invalid' );
 			});
@@ -334,7 +334,7 @@
 			accordionHeight =  46 * ( 1 + sections.length ) - 16; // Magic numbers.
 			diff = totalHeight - accordionHeight;
 			if ( 120 < diff && 290 > diff ) {
-				sections.css( 'max-height', diff );				
+				sections.css( 'max-height', diff );
 			} else if ( 120 >= diff ) {
 				this.$el.addClass( 'allow-scroll' );
 			}
@@ -1998,7 +1998,7 @@
 				event.stopPropagation();
 				event.preventDefault();
 			} );
-			$( '#accordion-panel-menus' ).on( 'click keydown', '.menu-delete', function() {
+			$( '#accordion-panel-menus' ).on( 'click keydown', '.menu-delete', function( event ) {
 				if ( api.utils.isKeydownButNotEnterEvent( event ) ) {
 					return;
 				}


### PR DESCRIPTION
Corrects an issue where delete did not work in firefox.