### PR TITLE
[WIP] Drag & drop sub menus

### DIFF
--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -1043,15 +1043,13 @@ class WP_Customize_Menus {
 
 		<script type="text/html" id="tmpl-loading-menu-item">
 			<li class="nav-menu-inserted-item-loading added-menu-item added-dbid-{{ data.id }} customize-control customize-control-menu_item nav-menu-item-wrap">
-				<div class="menu-item menu-item-depth-0 menu-item-edit-inactive">
-					<dl class="menu-item-bar">
-						<dt class="menu-item-handle">
-							<span class="spinner" style="visibility: visible;"></span>
-							<span class="item-type">{{ data.type_label }}</span>
-							<span class="item-title menu-item-title">{{{ data.name }}}</span>
-						</dt>
-					</dl>
-				</div>
+				<dl class="menu-item-bar">
+					<dt class="menu-item-handle">
+						<span class="spinner" style="visibility: visible;"></span>
+						<span class="item-type">{{ data.type_label }}</span>
+						<span class="item-title menu-item-title">{{{ data.name }}}</span>
+					</dt>
+				</dl>
 			</li>
 		</script>
 		<script type="text/html" id="tmpl-menu-item-reorder-nav">

--- a/class-wp-customize-menus.php
+++ b/class-wp-customize-menus.php
@@ -424,7 +424,7 @@ class WP_Customize_Menus {
 	public function register_scripts( $wp_scripts ) {
 		$handle = 'menu-customizer';
 		$src = plugin_dir_url( __FILE__ ) . 'menu-customizer.js';
-		$deps = array( 'jquery', 'wp-backbone', 'customize-controls', 'accordion', 'wp-a11y' );
+		$deps = array( 'jquery', 'wp-backbone', 'customize-controls', 'accordion', 'nav-menu', 'wp-a11y' );
 		$wp_scripts->add( $handle, $src, $deps );
 
 		$handle = 'customize-menus-preview';
@@ -486,6 +486,26 @@ class WP_Customize_Menus {
 		$data = sprintf( 'var _wpCustomizeMenusSettings = %s;', json_encode( $settings ) );
 		wp_scripts()->add_data( 'menu-customizer', 'data', $data );
 
+		// This is copied from nav-menus.php, and it has an unfortunate object name of `menus`.
+		$nav_menus_l10n = array(
+			'oneThemeLocationNoMenus' => null,
+			'moveUp'       => __( 'Move up one' ),
+			'moveDown'     => __( 'Move down one' ),
+			'moveToTop'    => __( 'Move to the top' ),
+			/* translators: %s: previous item name */
+			'moveUnder'    => __( 'Move under %s' ),
+			/* translators: %s: previous item name */
+			'moveOutFrom'  => __( 'Move out from under %s' ),
+			/* translators: %s: previous item name */
+			'under'        => __( 'Under %s' ),
+			/* translators: %s: previous item name */
+			'outFrom'      => __( 'Out from under %s' ),
+			/* translators: 1: item name, 2: item position, 3: total number of items */
+			'menuFocus'    => __( '%1$s. Menu item %2$d of %3$d.' ),
+			/* translators: 1: item name, 2: item position, 3: parent item name */
+			'subMenuFocus' => __( '%1$s. Sub item number %2$d under %3$s.' ),
+		);
+		wp_localize_script( 'nav-menu', 'menus', $nav_menus_l10n );
 	}
 
 	/**

--- a/menu-customize-controls.php
+++ b/menu-customize-controls.php
@@ -473,7 +473,6 @@ class WP_Customize_Menu_Item_Control extends WP_Customize_Control {
 	 */
 	public function content_template() {
 		?>
-		<div id="menu-item-{{ data.menu_item_id }}" class="{{ data.el_classes }}" data-item-depth="{{ data.depth }}">
 			<dl class="menu-item-bar">
 				<dt class="menu-item-handle">
 					<span class="item-type">{{{ data.item_type_label }}}</span>
@@ -546,7 +545,6 @@ class WP_Customize_Menu_Item_Control extends WP_Customize_Control {
 				<input type="hidden" name="menu-item-parent-id" class="menu-item-parent-id" id="edit-menu-item-parent-id-{{ data.menu_item_id }}" value="{{ data.parent }}" />
 			</div><!-- .menu-item-settings-->
 			<ul class="menu-item-transport"></ul>
-		</div>
 		<?php
 	}
 }

--- a/menu-customize-controls.php
+++ b/menu-customize-controls.php
@@ -542,7 +542,9 @@ class WP_Customize_Menu_Item_Control extends WP_Customize_Control {
 					<button type="button" class="not-a-button item-delete submitdelete deletion" id="delete-menu-item-{{ data.menu_item_id }}"><?php _e( 'Remove' ); ?></button>
 					<span class="spinner"></span>
 				</div>
-				<input type="hidden" name="menu-item-parent-id" class="menu-item-parent-id" id="edit-menu-item-parent-id-{{ data.menu_item_id }}" value="{{ data.parent }}" />
+
+				<input type="hidden" name="menu-item-db-id[{{ data.menu_item_id }}]" class="menu-item-data-db-id" value="{{ data.menu_item_id }}" />
+				<input type="hidden" name="menu-item-parent-id[{{ data.menu_item_id }}]" class="menu-item-data-parent-id" value="{{ data.parent }}" />
 			</div><!-- .menu-item-settings-->
 			<ul class="menu-item-transport"></ul>
 		<?php

--- a/menu-customizer.css
+++ b/menu-customizer.css
@@ -406,17 +406,40 @@
 /* Submenu depths. 30px even on nav-menus.php; need to reduce here for space. */
 /* WARNING: The factors will be hardcoded into the javascript, currently even. @todo varying depth factors in JS. */
 .menu-item-depth-0 { margin-left: 0px; }
-.menu-item-depth-1 { margin-left: 24px; }
-.menu-item-depth-2 { margin-left: 42px; }
-.menu-item-depth-3 { margin-left: 54px; }
-.menu-item-depth-4 { margin-left: 66px; }
-.menu-item-depth-5 { margin-left: 78px; }
+.menu-item-depth-1 { margin-left: 15px; }
+.menu-item-depth-2 { margin-left: 30px; }
+.menu-item-depth-3 { margin-left: 45px; }
+.menu-item-depth-4 { margin-left: 60px; }
+.menu-item-depth-5 { margin-left: 75px; }
 .menu-item-depth-6 { margin-left: 90px; }
-.menu-item-depth-7 { margin-left: 98px; }
-.menu-item-depth-8 { margin-left: 106px; }
-.menu-item-depth-9 { margin-left: 112px; }
-.menu-item-depth-10 { margin-left: 120px; }
-.menu-item-depth-11 { margin-left: 128px; }
+.menu-item-depth-7 { margin-left: 105px; }
+.menu-item-depth-8 { margin-left: 120px; }
+.menu-item-depth-9 { margin-left: 135px; }
+.menu-item-depth-10 { margin-left:150px; }
+.menu-item-depth-11 { margin-left:165px; }
+
+/* @todo handle .menu-item-settings width */
+.menu-item-depth-0  > .menu-item-bar { margin-right: 0px; }
+.menu-item-depth-1  > .menu-item-bar { margin-right: 15px; }
+.menu-item-depth-2  > .menu-item-bar { margin-right: 30px; }
+.menu-item-depth-3  > .menu-item-bar { margin-right: 45px; }
+.menu-item-depth-4  > .menu-item-bar { margin-right: 60px; }
+.menu-item-depth-5  > .menu-item-bar { margin-right: 75px; }
+.menu-item-depth-6  > .menu-item-bar { margin-right: 90px; }
+.menu-item-depth-7  > .menu-item-bar { margin-right: 105px; }
+.menu-item-depth-8  > .menu-item-bar { margin-right: 120px; }
+.menu-item-depth-9  > .menu-item-bar { margin-right: 135px; }
+.menu-item-depth-10 > .menu-item-bar { margin-right: 150px; }
+.menu-item-depth-11 > .menu-item-bar { margin-right: 165px; }
+
+.control-section-menu .menu .sortable-placeholder {
+	margin-top: 0;
+	margin-bottom: 1px;
+	max-width: calc(100% - 2px);
+	float: left;
+	display: list-item;
+	border-color: #a0a5aa;
+}
 
 .menu-item-depth-0 .menu-item-transport { margin-left: 0px; }
 .menu-item-depth-1 .menu-item-transport { margin-left: -12px; }

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -1572,8 +1572,7 @@
 		 * Set up the control.
 		 */
 		ready: function() {
-			//this.$controlSection = this.container.closest( '.control-section' );
-			this.$sectionContent = this.container.closest( '.accordion-section-content' );
+			var control = this;
 
 			control.$controlSection = control.container.closest( '.control-section' );
 			control.$sectionContent = control.container.closest( '.accordion-section-content' );

--- a/menu-customizer.js
+++ b/menu-customizer.js
@@ -5,7 +5,7 @@
 	if ( ! wp || ! wp.customize ) { return; }
 
 	// Set up our namespace.
-	var OldPreviewer, api = wp.customize;
+	var OldPreviewer;
 
 	/**
 	 * Set up wpNavMenu for drag and drop.


### PR DESCRIPTION
This PR is a clean version of the code from PR #63 without merge conflicts, which is attempting to fix #4. I will be going through the list of known issues and checking them off if they are fixed.

#### Known issues

- [ ] Pretty easy to drag an item out of menu and remove it inadvertantly
- [ ] Was able to drop submenu at top making it a child of nothing: http://cl.ly/image/3Y231T3m221U
- [ ] Was able to get grandchildren below top level without children with some rearranging: http://cl.ly/image/1y301d0J2m2k
- [ ] It looks like you can make a top level a sub menu of nothing.
- [ ] Preview doesn't work.
- [ ] The live Menu doesn't use the saved sort order.
- [ ] Sub-sub (grandchild) menu items are buggy. Moving them around makes them appear as child items in the preview, even if the Customizer still shows it as being a grandchild item.
- [ ] With the drag handle being all the way across, it's very easy to grab too far to the right of an item, and then not have sufficient space on the left to move a child / grandchild item up a level. Suggest that the drop target look at the top left of the menu item, and not where the cursor is. Top right if the Customizer is shown on the right for RTL.
- [ ] sub item marker isn't really scaleable - grandchild items may be expected to be sub sub item, and so on. Visually, the structure can already be seen, and for accesibility, I suggest adding aria attributes / wp.ally.speak() that says something like "Child Cat 3.1 is a child item of Parent Cat 3".

#### Dependancies

EDIT: You should also apply this PR to core https://github.com/xwp/wordpress-develop/pull/91 when testing.